### PR TITLE
Export also as `default`

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,3 +63,4 @@ var parseAss = function (text, options) {
 
 
 module.exports = parseAss;
+module.exports.default = parseAss;


### PR DESCRIPTION
This single-line change helps users to import by `import parseAss from "ass-parser"` on their ES2015 scripts processed by TypeScript or Babel.

For example:

```ts
import parseAss from "ass-parser";
parseAss("text");
```

This becomes:

```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
const ass_parser_1 = require("ass-parser");
ass_parser_1.default("text");
```